### PR TITLE
Fix README instructions and contract controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ Ceci est la répo du site web d'Amap'laneth, une association de type AMAP basée
 
 ## Démarrage
 
-- `npm i` Pour installer les dépendances js
-- `composer i` Pour installer les dépendances php
-- `cp .env.example .env` Générer le fichier .env
-- `php artisan key:generate` Générer la clé encryptage
-- `php artisan migrate` Générer la base de donéees
-- `npm run build` Générer les fichiers vite
-- `composer run dev` Pour démarrer le serveur
-- `pnpm i` et `composer i` Pour installer les dépendances
-- `npm run build` pour build le front
-- `php artisan serve` et `npm run dev` Pour démarrer le serveur
+1. `pnpm install` (ou `npm install`) pour installer les dépendances JavaScript.
+2. `composer install` pour installer les dépendances PHP.
+3. `cp .env.example .env` puis `php artisan key:generate` pour créer le fichier `.env` et générer la clé d'application.
+4. `php artisan migrate` pour créer la base de données.
+5. `composer run dev` pour lancer le serveur Laravel, le listener de queue et Vite.
+
+Vous pouvez également démarrer les services séparément avec `php artisan serve` et `npm run dev`.

--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -13,11 +13,11 @@ class ContractController extends Controller
     {
         Contract::insert([
             'title' => $request->get('title'),
-            'description' => $request->get('descritpion'),
+            'description' => $request->get('description'),
             'price' => $request->get('price'),
             'quantity' => $request->get('quantity')
         ]);
-        return "<p>Hello</p>";
+        return ['success' => 'contrat créé'];
     }
 
     public function allContracts()
@@ -35,7 +35,7 @@ class ContractController extends Controller
         Contract::find($id)
             ->update([
                 'title' => $request->get('title'),
-                'description' => $request->get('descritpion'),
+                'description' => $request->get('description'),
                 'price' => $request->get('price'),
                 'quantity' => $request->get('quantity')
             ]);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,8 @@
-(globalThis as any).route = (name: string) => `/${name}`;
-(globalThis as any).route = Object.assign((name: string) => `/${name}`, {
-    current: (name: string) => false,
-});
+(globalThis as any).route = (name?: string) => {
+    if (name) {
+        return `/${name}`;
+    }
+    return {
+        current: () => false,
+    };
+};


### PR DESCRIPTION
## Summary
- clarify how to start the server in README
- correct `descritpion` typo and return messages in `ContractController`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531485736c8328afc4c9e11b6c899f