### PR TITLE
Add hidden admin login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Hash du mot de passe administrateur (par défaut "az")
+ADMIN_PASSWORD_HASH="$2b$12$Qu9.fSxhjDSPaX3evcS2VuZP/VFCy0MRAU6YCRgXoIThRfid.SmmO"

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AdminController extends Controller
+{
+    public function token(): array
+    {
+        $token = Str::random(40);
+        session(['admin_login_token' => $token]);
+
+        return ['token' => $token];
+    }
+
+    public function loginPage(Request $request): Response
+    {
+        if ($request->session()->get('admin_login_token') !== $request->query('token')) {
+            abort(403);
+        }
+
+        return Inertia::render('Admin/Login', [
+            'token' => $request->query('token'),
+        ]);
+    }
+
+    public function login(Request $request)
+    {
+        if ($request->session()->get('admin_login_token') !== $request->input('token')) {
+            abort(403);
+        }
+
+        $request->validate([
+            'password' => ['required'],
+        ]);
+
+        $hash = env('ADMIN_PASSWORD_HASH');
+        if (!$hash || !Hash::check($request->input('password'), $hash)) {
+            return back()->withErrors(['password' => 'Mot de passe invalide']);
+        }
+
+        $request->session()->forget('admin_login_token');
+        $request->session()->put('is_admin', true);
+
+        return redirect()->route('home');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -34,6 +34,7 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
+            'isAdmin' => $request->session()->get('is_admin', false),
         ];
     }
 }

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -1,5 +1,6 @@
 import backgroundVector from '@images/background.svg';
-import { PropsWithChildren, ReactNode } from 'react';
+import { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { router } from '@inertiajs/react';
 import Footer from './Footer';
 import Header from './Header';
 
@@ -8,6 +9,40 @@ export default function FrontOffice({
     image,
     children,
 }: PropsWithChildren<{ header?: ReactNode; image?: string }>) {
+    useEffect(() => {
+        const sequence = [
+            'ArrowUp',
+            'ArrowUp',
+            'ArrowDown',
+            'ArrowDown',
+            'ArrowLeft',
+            'ArrowRight',
+            'ArrowLeft',
+            'ArrowRight',
+            'b',
+            'a',
+        ];
+        let position = 0;
+        function onKeyDown(e: KeyboardEvent) {
+            if (e.key === sequence[position]) {
+                position += 1;
+                if (position === sequence.length) {
+                    fetch(route('admin.token'))
+                        .then((r) => r.json())
+                        .then((data) => {
+                            window.location.href = route('admin.login', {
+                                token: data.token,
+                            });
+                        });
+                    position = 0;
+                }
+            } else {
+                position = 0;
+            }
+        }
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, []);
     return (
         <div
             className="absolute -z-10 bg-center bg-top bg-repeat-y"

--- a/resources/js/Layouts/Header.tsx
+++ b/resources/js/Layouts/Header.tsx
@@ -1,9 +1,11 @@
 import ApplicationLogo from '@/Components/ApplicationLogo';
 import NavLink from '@/Components/NavLink';
-import { Link } from '@inertiajs/react';
+import { Link, usePage } from '@inertiajs/react';
 import { useState } from 'react';
 
 export default function Header() {
+    const { props } = usePage<{ isAdmin: boolean }>();
+    const isAdmin = props.isAdmin;
     const [isMenuBurgerOpen, setIsMenuBurgerOpen] = useState(false);
 
     function toggleMenuBurger() {
@@ -15,6 +17,11 @@ export default function Header() {
                 <Link href="/">
                     <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200" />
                 </Link>
+                {isAdmin && (
+                    <span className="ml-4 rounded bg-red-600 px-2 py-1 text-xs font-bold text-white">
+                        ADMIN MODE
+                    </span>
+                )}
                 <button
                     data-collapse-toggle="navbar-default"
                     type="button"

--- a/resources/js/Pages/Admin/Login.tsx
+++ b/resources/js/Pages/Admin/Login.tsx
@@ -1,0 +1,30 @@
+import { router } from '@inertiajs/react';
+import { FormEvent, useState } from 'react';
+
+export default function AdminLogin({ token }: { token: string }) {
+    const [password, setPassword] = useState('');
+
+    function handleSubmit(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        router.post('/admin/login', { password, token });
+    }
+
+    return (
+        <div className="flex h-screen items-center justify-center">
+            <form onSubmit={handleSubmit} className="flex items-center gap-2">
+                <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="rounded border p-2"
+                />
+                <button
+                    type="submit"
+                    className="rounded bg-blue-600 px-4 py-2 text-white"
+                >
+                    Valider
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Mail\ContactMail;
+use App\Http\Controllers\AdminController;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
@@ -29,3 +30,7 @@ Route::get('/contact', function () {
 Route::post('/send-mail', function (Request $request) {
     Mail::to('amaplaneth@riseup.net')->send(new ContactMail($request));
 })->name('send');
+
+Route::get('/admin/token', [AdminController::class, 'token'])->name('admin.token');
+Route::get('/admin/login', [AdminController::class, 'loginPage'])->name('admin.login');
+Route::post('/admin/login', [AdminController::class, 'login'])->name('admin.login.post');


### PR DESCRIPTION
## Summary
- store admin password hash in `.env.example`
- share admin state with Inertia
- add admin login routes and controller
- create login page and secret key sequence to reach it
- show admin indicator in header

## Testing
- `pnpm run lint` *(fails: some options not available)*
- `pnpm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559a0bc5188328b562b6f1d3d47f1a