### PR TITLE
Fix admin key sequence security and sanitize email output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_URL=http://localhost
 APP_NAME=Laravel
 VITE_APP_NAME="${APP_NAME}"
 ADMIN_PASSWORD_HASH=""
+ADMIN_SEQUENCE="ArrowUp,ArrowUp,ArrowDown,ArrowDown,ArrowLeft,ArrowRight,ArrowLeft,ArrowRight,b,a"
 
 MAIL_MAILER=log
 MAIL_SCHEME=null

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ APP_URL : URL publique de l'application (ex : http://localhost:8000 en local)
 APP_NAME : Nom de l’application côté Laravel
 VITE_APP_NAME : Nom de l’application utilisé côté React via Vite, reprend APP_NAME, mais peut être personnalisé si nécessaire
 ADMIN_PASSWORD_HASH : Mot de passe administrateur hashé avec Bcrypt. Générer avec `php artisan tinker` → `Hash::make('password')`
+ADMIN_SEQUENCE : Suite de touches à saisir pour accéder au formulaire d'administration.
 
 MAIL_MAILER : Méthode d'envoi des emails. log pour enregistrer les emails dans les logs (utile en local), smtp en production.
 MAIL_SCHEME : Protocole d’envoi (souvent null, sauf besoin spécifique).

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -10,12 +10,27 @@ use Inertia\Response;
 
 class AdminController extends Controller
 {
-    public function token(): array
+    public function keyStep(Request $request)
     {
-        $token = Str::random(40);
-        session(['admin_login_token' => $token]);
+        $sequence = explode(',', env('ADMIN_SEQUENCE'));
+        $position = $request->session()->get('admin_key_position', 0);
 
-        return ['token' => $token];
+        if ($request->query('key') === ($sequence[$position] ?? null)) {
+            $position++;
+            if ($position === count($sequence)) {
+                $request->session()->forget('admin_key_position');
+                $token = Str::random(40);
+                $request->session()->put('admin_login_token', $token);
+
+                return ['token' => $token];
+            }
+
+            $request->session()->put('admin_key_position', $position);
+        } else {
+            $request->session()->put('admin_key_position', 0);
+        }
+
+        return [];
     }
 
     public function loginPage(Request $request): Response

--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -11,12 +11,15 @@ class ContractController extends Controller
 
     public function createContract(Request $request)
     {
-        Contract::insert([
-            'title' => $request->get('title'),
-            'description' => $request->get('description'),
-            'price' => $request->get('price'),
-            'quantity' => $request->get('quantity')
+        $data = $request->validate([
+            'title' => ['required', 'string'],
+            'description' => ['required', 'string'],
+            'price' => ['required', 'numeric'],
+            'quantity' => ['required', 'integer'],
         ]);
+
+        Contract::create($data);
+
         return ['success' => 'contrat créé'];
     }
 
@@ -32,13 +35,15 @@ class ContractController extends Controller
 
     public function editContract(int $id, Request $request)
     {
-        Contract::find($id)
-            ->update([
-                'title' => $request->get('title'),
-                'description' => $request->get('description'),
-                'price' => $request->get('price'),
-                'quantity' => $request->get('quantity')
-            ]);
+        $data = $request->validate([
+            'title' => ['required', 'string'],
+            'description' => ['required', 'string'],
+            'price' => ['required', 'numeric'],
+            'quantity' => ['required', 'integer'],
+        ]);
+
+        Contract::findOrFail($id)->update($data);
+
         return ['success' => 'contrat mis à jour'];
     }
 

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -10,12 +10,15 @@ class ImageController extends Controller
 {
     public function createImage(Request $request)
     {
-        Image::insert([
-            'title' => $request->get('title'),
-            'alt_text' => $request->get('alt_text'),
-            'url' => $request->get('url'),
+        $data = $request->validate([
+            'title' => ['required', 'string'],
+            'alt_text' => ['required', 'string'],
+            'url' => ['required', 'string'],
         ]);
-        return "success";
+
+        Image::create($data);
+
+        return 'success';
     }
 
     public function allImages()
@@ -30,12 +33,14 @@ class ImageController extends Controller
 
     public function editImage(int $id, Request $request)
     {
-        Image::find($id)
-            ->update([
-                'title' => $request->get('title'),
-                'alt_text' => $request->get('alt_text'),
-                'url' => $request->get('url'),
-            ]);
+        $data = $request->validate([
+            'title' => ['required', 'string'],
+            'alt_text' => ['required', 'string'],
+            'url' => ['required', 'string'],
+        ]);
+
+        Image::findOrFail($id)->update($data);
+
         return ['success' => 'image mis à jour'];
     }
 

--- a/app/Http/Controllers/ProducerController.php
+++ b/app/Http/Controllers/ProducerController.php
@@ -10,16 +10,19 @@ class ProducerController extends Controller
 {
     public function createProducer(Request $request)
     {
-        Producer::insert([
-            'profile_picture' => $request->get('profile_picture'),
-            'first_name' => $request->get('first_name'),
-            'last_name' => $request->get('last_name'),
-            'address_road' => $request->get('address_road'),
-            'zipcode' => $request->get('zipcode'),
-            'city' => $request->get('city'),
-            'description' => $request->get('description')
+        $data = $request->validate([
+            'profile_picture' => ['required', 'string'],
+            'first_name' => ['required', 'string'],
+            'last_name' => ['required', 'string'],
+            'address_road' => ['required', 'string'],
+            'zipcode' => ['required', 'string'],
+            'city' => ['required', 'string'],
+            'description' => ['required', 'string'],
         ]);
-        return "success";
+
+        Producer::create($data);
+
+        return 'success';
     }
 
     public function allProducers()
@@ -34,16 +37,18 @@ class ProducerController extends Controller
 
     public function editProducer(int $id, Request $request)
     {
-        Producer::find($id)
-            ->update([
-                'profile_picture' => $request->get('profile_picture'),
-                'first_name' => $request->get('first_name'),
-                'last_name' => $request->get('last_name'),
-                'address_road' => $request->get('address_road'),
-                'zipcode' => $request->get('zipcode'),
-                'city' => $request->get('city'),
-                'description' => $request->get('description')
-            ]);
+        $data = $request->validate([
+            'profile_picture' => ['required', 'string'],
+            'first_name' => ['required', 'string'],
+            'last_name' => ['required', 'string'],
+            'address_road' => ['required', 'string'],
+            'zipcode' => ['required', 'string'],
+            'city' => ['required', 'string'],
+            'description' => ['required', 'string'],
+        ]);
+
+        Producer::findOrFail($id)->update($data);
+
         return ['success' => 'Producer mis à jour'];
     }
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -10,12 +10,15 @@ class ProductController extends Controller
 {
     public function createProduct(Request $request)
     {
-        Product::insert([
-            'label' => $request->get('label'),
-            'season_start' => $request->get('season_start'),
-            'season_end' => $request->get('season_end'),
+        $data = $request->validate([
+            'label' => ['required', 'string'],
+            'season_start' => ['required', 'string'],
+            'season_end' => ['required', 'string'],
         ]);
-        return "success";
+
+        Product::create($data);
+
+        return 'success';
     }
 
     public function allProducts()
@@ -30,12 +33,14 @@ class ProductController extends Controller
 
     public function editProduct(int $id, Request $request)
     {
-        Product::find($id)
-            ->update([
-                'label' => $request->get('label'),
-                'season_start' => $request->get('season_start'),
-                'season_end' => $request->get('season_end'),
-            ]);
+        $data = $request->validate([
+            'label' => ['required', 'string'],
+            'season_start' => ['required', 'string'],
+            'season_end' => ['required', 'string'],
+        ]);
+
+        Product::findOrFail($id)->update($data);
+
         return ['success' => 'Product mis à jour'];
     }
 

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class Admin
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!$request->session()->get('is_admin')) {
+            return response()->json(['error' => 'Forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Mail/ContactMail.php
+++ b/app/Mail/ContactMail.php
@@ -30,7 +30,7 @@ class ContactMail extends Mailable
     public function envelope(): Envelope
     {
         $subject = '';
-        if ($this->message->subject == "Je suis un producteur") {
+        if ($this->message->subject == "Un producteur") {
             $subject = 'Prise de contact du producteur ' . $this->message->name;
         } else {
             $subject = 'Demande de renseignement de ' . $this->message->name;
@@ -49,7 +49,7 @@ class ContactMail extends Mailable
         return new Content(
             view: 'mail',
             with: [
-                'content' => $this->message->content
+                'content' => $this->message->body,
             ]
         );
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,6 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\Admin::class,
+        ]);
+
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class,
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,

--- a/database/migrations/2025_05_07_123801_create_producer_contracts_table.php
+++ b/database/migrations/2025_05_07_123801_create_producer_contracts_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('producer_contracts', function (Blueprint $table) {
             $table->foreignId('id_producer');
-            $table->foreignId('id_product');
+            $table->foreignId('id_contract');
         });
     }
 

--- a/resources/js/Components/Home/ConvivialitySlider.tsx
+++ b/resources/js/Components/Home/ConvivialitySlider.tsx
@@ -1,0 +1,31 @@
+import { Autoplay, Navigation } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/navigation';
+
+export default function ConvivialitySlider({ images }: { images: string[] }) {
+    return (
+        <section className="mx-4 mb-8 mt-20 md:mx-8">
+            <div className="h-full w-full rounded-lg bg-black p-5">
+                <h2 className="my-4 text-center text-2xl font-bold uppercase dark:text-gray-200">
+                    Une convivialité qui rapproche
+                </h2>
+                <Swiper
+                    navigation
+                    modules={[Autoplay, Navigation]}
+                    loop
+                    autoplay={{ delay: 2500, disableOnInteraction: false }}
+                    className="conviviality"
+                >
+                    {images.map((img, index) => (
+                        <SwiperSlide
+                            key={index}
+                            className="bg-cover bg-center"
+                            style={{ backgroundImage: `url(${img})` }}
+                        />
+                    ))}
+                </Swiper>
+            </div>
+        </section>
+    );
+}

--- a/resources/js/Components/Home/ProductsCarousel.tsx
+++ b/resources/js/Components/Home/ProductsCarousel.tsx
@@ -1,0 +1,45 @@
+import { Autoplay, Navigation } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/navigation';
+
+export type ImageSlide = {
+    label: string;
+    url: string;
+};
+
+export default function ProductsCarousel({ images }: { images: ImageSlide[] }) {
+    return (
+        <section className="mx-4 my-20 flex flex-col items-center md:mx-8">
+            <h2 className="my-3 text-2xl font-bold">LES PRODUITS PROPOSÉS</h2>
+            <div className="flex w-full flex-row justify-between">
+                <Swiper
+                    className="products"
+                    navigation
+                    slidesPerView={5}
+                    spaceBetween={30}
+                    breakpoints={{
+                        425: { slidesPerView: 2, spaceBetween: 20 },
+                        768: { slidesPerView: 4, spaceBetween: 40 },
+                        1024: { slidesPerView: 5, spaceBetween: 50 },
+                    }}
+                    modules={[Autoplay, Navigation]}
+                    loop
+                    autoplay={{ delay: 2500, disableOnInteraction: false }}
+                >
+                    {images.map((image) => (
+                        <SwiperSlide key={image.label}>
+                            <div>
+                                <div
+                                    className="h-[100px] w-auto rounded-lg bg-center"
+                                    style={{ backgroundImage: `url(${image.url})` }}
+                                ></div>
+                                <p className="text-center">{image.label}</p>
+                            </div>
+                        </SwiperSlide>
+                    ))}
+                </Swiper>
+            </div>
+        </section>
+    );
+}

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -9,36 +9,16 @@ export default function FrontOffice({
     children,
 }: PropsWithChildren<{ header?: ReactNode; image?: string }>) {
     useEffect(() => {
-        const sequence = [
-            'ArrowUp',
-            'ArrowUp',
-            'ArrowDown',
-            'ArrowDown',
-            'ArrowLeft',
-            'ArrowRight',
-            'ArrowLeft',
-            'ArrowRight',
-            'b',
-            'a',
-        ];
-        let position = 0;
         function onKeyDown(e: KeyboardEvent) {
-            if (e.key === sequence[position]) {
-                position += 1;
-                if (position === sequence.length) {
-                    fetch(route('admin.token'))
-                        .then((r) => r.json())
-                        .then((data) => {
-                            window.location.href = route('admin.login', {
-                                token: data.token,
-                            });
-                        });
-                    position = 0;
-                }
-            } else {
-                position = 0;
-            }
+            fetch(route('admin.keyStep', { key: e.key }))
+                .then((r) => r.json())
+                .then((data) => {
+                    if (data.token) {
+                        window.location.href = route('admin.login', { token: data.token });
+                    }
+                });
         }
+
         window.addEventListener('keydown', onKeyDown);
         return () => window.removeEventListener('keydown', onKeyDown);
     }, []);

--- a/resources/js/Pages/Contact.tsx
+++ b/resources/js/Pages/Contact.tsx
@@ -78,8 +78,9 @@ export default function Contact() {
                     </h2>
                     <form onSubmit={handleSubmit} className="w-full p-5">
                         <div className="flex flex-col">
-                            <InputLabel>Prénom / Nom</InputLabel>
+                            <InputLabel htmlFor="name">Prénom / Nom</InputLabel>
                             <TextInput
+                                id="name"
                                 value={name}
                                 name="name"
                                 required
@@ -89,8 +90,9 @@ export default function Contact() {
                             {/* <InputError message={'test'} /> */}
                         </div>
                         <div className="flex flex-col">
-                            <label>Je suis... </label>
+                            <label htmlFor="subject">Je suis... </label>
                             <select
+                                id="subject"
                                 value={subject}
                                 name="subject"
                                 required
@@ -105,8 +107,9 @@ export default function Contact() {
                             </select>
                         </div>
                         <div className="flex flex-col">
-                            <InputLabel>Email</InputLabel>
+                            <InputLabel htmlFor="email">Email</InputLabel>
                             <TextInput
+                                id="email"
                                 value={email}
                                 name="email"
                                 required
@@ -117,8 +120,9 @@ export default function Contact() {
                             {/* <InputError message={'test'} /> */}
                         </div>
                         <div className="flex flex-col">
-                            <InputLabel>Numéro de téléphone</InputLabel>
+                            <InputLabel htmlFor="phone">Numéro de téléphone</InputLabel>
                             <TextInput
+                                id="phone"
                                 value={phone}
                                 name="phone"
                                 onChange={(e) => setPhone(e.target.value)}
@@ -128,8 +132,9 @@ export default function Contact() {
                             {/* <InputError message={'test'} /> */}
                         </div>
                         <div className="flex flex-col">
-                            <InputLabel>Message</InputLabel>
+                            <InputLabel htmlFor="message">Message</InputLabel>
                             <textarea
+                                id="message"
                                 value={content}
                                 name="message"
                                 required

--- a/resources/js/Pages/Home.tsx
+++ b/resources/js/Pages/Home.tsx
@@ -9,15 +9,8 @@ import nearFarmers from '@images/near_farmers.jpg';
 import plant from '@images/plant.jpg';
 import raddish from '@images/raddish.jpg';
 import salad from '@images/salad.jpg';
-import 'swiper/css';
-import 'swiper/css/navigation';
-import { Autoplay, Navigation } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
-
-type ImageSlide = {
-    label: string;
-    url: string;
-};
+import ProductsCarousel, { ImageSlide } from '@/Components/Home/ProductsCarousel';
+import ConvivialitySlider from '@/Components/Home/ConvivialitySlider';
 
 export default function Home() {
     const imagesToSlide: ImageSlide[] = [
@@ -71,53 +64,7 @@ export default function Home() {
             }
             image={helpField}
         >
-            <section className="mx-4 my-20 flex flex-col items-center md:mx-8">
-                <h2 className="my-3 text-2xl font-bold">
-                    LES PRODUITS PROPOSÉS
-                </h2>
-                <div className="flex w-full flex-row justify-between">
-                    <Swiper
-                        className="products"
-                        navigation={true}
-                        slidesPerView={5}
-                        spaceBetween={30}
-                        breakpoints={{
-                            425: {
-                                slidesPerView: 2,
-                                spaceBetween: 20,
-                            },
-                            768: {
-                                slidesPerView: 4,
-                                spaceBetween: 40,
-                            },
-                            1024: {
-                                slidesPerView: 5,
-                                spaceBetween: 50,
-                            },
-                        }}
-                        modules={[Autoplay, Navigation]}
-                        loop={true}
-                        autoplay={{
-                            delay: 2500,
-                            disableOnInteraction: false,
-                        }}
-                    >
-                        {imagesToSlide.map((image) => (
-                            <SwiperSlide key={image.label}>
-                                <div>
-                                    <div
-                                        className="h-[100px] w-auto rounded-lg bg-center"
-                                        style={{
-                                            backgroundImage: `url(${image.url})`,
-                                        }}
-                                    ></div>
-                                    <p className="text-center">{image.label}</p>
-                                </div>
-                            </SwiperSlide>
-                        ))}
-                    </Swiper>
-                </div>
-            </section>
+            <ProductsCarousel images={imagesToSlide} />
             <section className="mx-4 my-20 md:mx-8 md:grid md:grid-cols-[2fr,1fr]">
                 <article className="mr-4">
                     <h2 className="my-3 text-2xl font-bold uppercase">
@@ -195,60 +142,19 @@ export default function Home() {
                     </p>
                 </article>
             </section>
-            <section className="mx-4 mb-8 mt-20 md:mx-8">
-                <div className="h-full w-full rounded-lg bg-black p-5">
-                    <h2 className="my-4 text-center text-2xl font-bold uppercase dark:text-gray-200">
-                        Une convivialité qui rapproche
-                    </h2>
-                    <Swiper
-                        navigation={true}
-                        modules={[Autoplay, Navigation]}
-                        loop={true}
-                        autoplay={{
-                            delay: 2500,
-                            disableOnInteraction: false,
-                        }}
-                        className="conviviality"
-                    >
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${helpField})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                        <SwiperSlide
-                            className="bg-cover bg-center"
-                            style={{ backgroundImage: `url(${distrib})` }}
-                        ></SwiperSlide>
-                    </Swiper>
-                </div>
-            </section>
+            <ConvivialitySlider
+                images={[
+                    distrib,
+                    helpField,
+                    distrib,
+                    distrib,
+                    distrib,
+                    distrib,
+                    distrib,
+                    distrib,
+                    distrib,
+                ]}
+            />
             <p className="mx-4 text-center md:mx-8">
                 Lorem ipsum dolor sit amet consectetur. Tristique in egestas
                 nisi vitae curabitur amet egestas eleifend volutpat. Eget donec

--- a/resources/views/mail.blade.php
+++ b/resources/views/mail.blade.php
@@ -1,1 +1,1 @@
-{!! $content !!}
+{{ $content }}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\ProducerController;
 use App\Http\Controllers\ProductController;
 use Illuminate\Support\Facades\Route;
 
+Route::middleware('admin')->group(function () {
+
 Route::group(['prefix' => 'contracts'], function () {
     Route::post('', [ContractController::class, 'createContract'])->name('contracts.store');
     Route::get('{id}', [ContractController::class, 'getContract'])->name('contracts.read');
@@ -36,4 +38,6 @@ Route::group(['prefix' => 'products'], function () {
     Route::get('', [ProductController::class, 'allProducts'])->name('products.show');
     Route::put('{id}', [ProductController::class, 'editProduct'])->name('products.update');
     Route::delete('{id}', [ProductController::class, 'destroyProduct'])->name('products.destroy');
+});
+
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,6 @@ Route::post('/send-mail', function (Request $request) {
     Mail::to('amaplaneth@riseup.net')->send(new ContactMail($request));
 })->name('send');
 
-Route::get('/admin/token', [AdminController::class, 'token'])->name('admin.token');
+Route::get('/admin/key-step', [AdminController::class, 'keyStep'])->name('admin.keyStep');
 Route::get('/admin/login', [AdminController::class, 'loginPage'])->name('admin.login');
 Route::post('/admin/login', [AdminController::class, 'login'])->name('admin.login.post');

--- a/tests/contact.test.tsx
+++ b/tests/contact.test.tsx
@@ -6,26 +6,32 @@ import Contact from '../resources/js/Pages/Contact';
 
 vi.mock('@inertiajs/inertia'); // Mock Inertia for POST requests
 
-describe('UserForm', () => {
+describe('Contact form', () => {
     it('submits form data via Inertia.post', async () => {
         const mockPost = vi.fn();
         Inertia.post = mockPost;
 
         render(<Contact />);
 
-        fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
+        fireEvent.change(screen.getByLabelText(/Prénom/i), {
             target: { value: 'John Doe' },
         });
 
-        fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+        fireEvent.change(screen.getByLabelText(/Email/i), {
             target: { value: 'john@example.com' },
         });
 
-        fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+        fireEvent.change(screen.getByLabelText(/Message/i), {
+            target: { value: 'Hello' },
+        });
 
-        expect(mockPost).toHaveBeenCalledWith('/users', {
+        fireEvent.click(screen.getByRole('button', { name: /Envoyer/i }));
+
+        expect(mockPost).toHaveBeenCalledWith('/send-mail', {
             name: 'John Doe',
             email: 'john@example.com',
+            subject: 'Un curieux',
+            body: 'Hello',
         });
     });
 });


### PR DESCRIPTION
## Summary
- protect API routes with new `admin` middleware
- move admin key sequence logic server-side via `keyStep` route
- sanitize email blade and fix subject/body handling
- add validation rules for CRUD controllers
- fix database pivot field name
- update contact form accessibility and test
- break up long `Home.tsx` into components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855df12f3c883289750866c9feab665