### PR TITLE
Handle admin login client-side sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ APP_KEY : Clé de chiffrement utilisée par Laravel. Générée via `php artisan
 APP_URL : URL publique de l'application (ex : http://localhost:8000 en local)
 APP_NAME : Nom de l’application côté Laravel
 VITE_APP_NAME : Nom de l’application utilisé côté React via Vite, reprend APP_NAME, mais peut être personnalisé si nécessaire
-ADMIN_SEQUENCE : Suite de touches à saisir pour accéder au formulaire d'administration
-ADMIN_TOKEN_LIFETIME : Durée de vie du token de connexion
+ADMIN_SEQUENCE : Suite de touches à saisir pour accéder au formulaire d'administration. La séquence est vérifiée côté navigateur.
+ADMIN_TOKEN_LIFETIME : Durée de vie du token de connexion et de la session administrateur
 ADMIN_BACKUP_EMAIL : Adresse où sera envoyé le lien d'initialisation du mot de passe administrateur
 
 MAIL_MAILER : Méthode d'envoi des emails. log pour enregistrer les emails dans les logs (utile en local), smtp en production.

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -16,28 +16,13 @@ class AdminController extends Controller
 {
     public function keyStep(Request $request)
     {
-        $sequence = explode(',', env('ADMIN_SEQUENCE'));
-        $position = $request->session()->get('admin_key_position', 0);
+        $token = Str::random(40);
+        $duration = env('ADMIN_TOKEN_LIFETIME', 30);
+        $expires = Carbon::now()->addMinutes($duration)->timestamp;
+        $request->session()->put('admin_login_token', $token);
+        $request->session()->put('admin_login_token_expires', $expires);
 
-        if ($request->query('key') === ($sequence[$position] ?? null)) {
-            $position++;
-            if ($position === count($sequence)) {
-                $request->session()->forget('admin_key_position');
-                $token = Str::random(40);
-                $duration = env('ADMIN_TOKEN_LIFETIME', 30);
-                $expires = Carbon::now()->addMinutes($duration)->timestamp;
-                $request->session()->put('admin_login_token', $token);
-                $request->session()->put('admin_login_token_expires', $expires);
-
-                return ['token' => $token];
-            }
-
-            $request->session()->put('admin_key_position', $position);
-        } else {
-            $request->session()->put('admin_key_position', 0);
-        }
-
-        return [];
+        return ['token' => $token];
     }
 
     public function loginPage(Request $request): Response
@@ -73,7 +58,9 @@ class AdminController extends Controller
 
         $request->session()->forget('admin_login_token');
         $request->session()->forget('admin_login_token_expires');
+        $duration = env('ADMIN_TOKEN_LIFETIME', 30);
         $request->session()->put('is_admin', true);
+        $request->session()->put('is_admin_expires', Carbon::now()->addMinutes($duration)->timestamp);
 
         return redirect()->route('home');
     }
@@ -81,6 +68,7 @@ class AdminController extends Controller
     public function logout(Request $request)
     {
         $request->session()->forget('is_admin');
+        $request->session()->forget('is_admin_expires');
 
         return redirect()->route('home');
     }
@@ -135,8 +123,12 @@ class AdminController extends Controller
         $admin->reset_token_expires = null;
         $admin->save();
 
-        $request->session()->put('is_admin', true);
+        $token = Str::random(40);
+        $duration = env('ADMIN_TOKEN_LIFETIME', 30);
+        $expires = Carbon::now()->addMinutes($duration)->timestamp;
+        $request->session()->put('admin_login_token', $token);
+        $request->session()->put('admin_login_token_expires', $expires);
 
-        return redirect()->route('home');
+        return redirect()->route('admin.login', ['token' => $token]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -29,12 +30,26 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        $isAdmin = false;
+        if ($request->session()->get('is_admin')) {
+            $expires = $request->session()->get('is_admin_expires', 0);
+            if ($expires >= time()) {
+                $isAdmin = true;
+                $duration = env('ADMIN_TOKEN_LIFETIME', 30);
+                $request->session()->put('is_admin_expires', Carbon::now()->addMinutes($duration)->timestamp);
+            } else {
+                $request->session()->forget('is_admin');
+                $request->session()->forget('is_admin_expires');
+            }
+        }
+
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
             ],
-            'isAdmin' => $request->session()->get('is_admin', false),
+            'isAdmin' => $isAdmin,
+            'adminSequence' => explode(',', env('ADMIN_SEQUENCE')),
         ];
     }
 }

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -1,5 +1,6 @@
 import backgroundVector from '@images/background.svg';
 import { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { usePage } from '@inertiajs/react';
 import Footer from './Footer';
 import Header from './Header';
 
@@ -8,22 +9,35 @@ export default function FrontOffice({
     image,
     children,
 }: PropsWithChildren<{ header?: ReactNode; image?: string }>) {
+    const { props } = usePage<{ adminSequence: string[] }>();
+
     useEffect(() => {
+        const sequence = props.adminSequence ?? [];
+        let position = 0;
+
         function onKeyDown(e: KeyboardEvent) {
-            fetch(route('admin.keyStep', { key: e.key }))
-                .then((r) => r.json())
-                .then((data) => {
-                    if (data.token) {
-                        window.location.href = route('admin.login', {
-                            token: data.token,
+            if (e.key === sequence[position]) {
+                position++;
+                if (position === sequence.length) {
+                    position = 0;
+                    fetch(route('admin.keyStep'))
+                        .then((r) => r.json())
+                        .then((data) => {
+                            if (data.token) {
+                                window.location.href = route('admin.login', {
+                                    token: data.token,
+                                });
+                            }
                         });
-                    }
-                });
+                }
+            } else {
+                position = 0;
+            }
         }
 
         window.addEventListener('keydown', onKeyDown);
         return () => window.removeEventListener('keydown', onKeyDown);
-    }, []);
+    }, [props.adminSequence]);
     return (
         <div
             className="absolute -z-10 bg-top bg-repeat-y"


### PR DESCRIPTION
## Summary
- simplify admin key step handler and return token directly
- handle admin mode expiry in middleware
- generate login token when setting password
- manage admin token lifetime on login/logout
- check key combo on the frontend only
- document key combo handling

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560856ab988328984f4f32668ac717