### PR TITLE
Implement admin key sequence verification

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -16,6 +16,11 @@ class AdminController extends Controller
 {
     public function keyStep(Request $request)
     {
+        $sequence = $request->input('sequence', []);
+        if ($sequence !== explode(',', (string) env('ADMIN_SEQUENCE'))) {
+            abort(403);
+        }
+
         $token = Str::random(40);
         $duration = env('ADMIN_TOKEN_LIFETIME', 30);
         $expires = Carbon::now()->addMinutes($duration)->timestamp;

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -20,7 +20,13 @@ export default function FrontOffice({
                 position++;
                 if (position === sequence.length) {
                     position = 0;
-                    fetch(route('admin.keyStep'))
+                    fetch(route('admin.keyStep'), {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({ sequence }),
+                    })
                         .then((r) => r.json())
                         .then((data) => {
                             if (data.token) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ Route::post('/send-mail', function (Request $request) {
     Mail::to('amaplaneth@riseup.net')->send(new ContactMail($request));
 })->name('send');
 
-Route::get('/admin/key-step', [AdminController::class, 'keyStep'])->name('admin.keyStep');
+Route::post('/admin/key-step', [AdminController::class, 'keyStep'])->name('admin.keyStep');
 Route::get('/admin/login', [AdminController::class, 'loginPage'])->name('admin.login');
 Route::post('/admin/login', [AdminController::class, 'login'])->name('admin.login.post');
 Route::post('/admin/logout', [AdminController::class, 'logout'])->name('admin.logout');


### PR DESCRIPTION
## Summary
- add server-side verification of the admin key sequence
- switch `/admin/key-step` to POST and send typed sequence from the client

## Testing
- `npm run lint` *(fails: Invalid option `--ignore-path` but no lint errors shown)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566f607e548328a9e6445f642dbdaf