### PR TITLE
Redirect to admin login after key sequence

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -27,7 +27,7 @@ class AdminController extends Controller
         $request->session()->put('admin_login_token', $token);
         $request->session()->put('admin_login_token_expires', $expires);
 
-        return ['token' => $token];
+        return redirect()->route('admin.login', ['token' => $token]);
     }
 
     public function loginPage(Request $request): Response

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -1,6 +1,6 @@
 import backgroundVector from '@images/background.svg';
 import { PropsWithChildren, ReactNode, useEffect } from 'react';
-import { usePage } from '@inertiajs/react';
+import { usePage, router } from '@inertiajs/react';
 import Footer from './Footer';
 import Header from './Header';
 
@@ -20,21 +20,7 @@ export default function FrontOffice({
                 position++;
                 if (position === sequence.length) {
                     position = 0;
-                    fetch(route('admin.keyStep'), {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({ sequence }),
-                    })
-                        .then((r) => r.json())
-                        .then((data) => {
-                            if (data.token) {
-                                window.location.href = route('admin.login', {
-                                    token: data.token,
-                                });
-                            }
-                        });
+                    router.post(route('admin.keyStep'), { sequence });
                 }
             } else {
                 position = 0;


### PR DESCRIPTION
## Summary
- redirect to `admin.login` after verifying the secret sequence
- use Inertia router to POST the `keyStep`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: ESLint invalid option)*

------
https://chatgpt.com/codex/tasks/task_e_685674c63b7c832880938680687d1925