### PR TITLE
Enhance admin password recovery flow

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -27,27 +27,25 @@ class AdminController extends Controller
         $request->session()->put('admin_login_token', $token);
         $request->session()->put('admin_login_token_expires', $expires);
 
-        return redirect()->route('admin.login', ['token' => $token]);
+        return redirect()->route('admin.login');
     }
 
     public function loginPage(Request $request): Response
     {
         $token = $request->session()->get('admin_login_token');
         $expires = $request->session()->get('admin_login_token_expires');
-        if (!$token || $token !== $request->query('token') || $expires < time()) {
+        if (!$token || $expires < time()) {
             abort(403);
         }
 
-        return Inertia::render('Admin/Login', [
-            'token' => $request->query('token'),
-        ]);
+        return Inertia::render('Admin/Login');
     }
 
     public function login(Request $request)
     {
         $token = $request->session()->get('admin_login_token');
         $expires = $request->session()->get('admin_login_token_expires');
-        if (!$token || $token !== $request->input('token') || $expires < time()) {
+        if (!$token || $expires < time()) {
             abort(403);
         }
 
@@ -78,21 +76,29 @@ class AdminController extends Controller
         return redirect()->route('home');
     }
 
-    public function forgotPassword()
+    public function forgotPassword(Request $request)
     {
-        $admin = AdminPassword::firstOrCreate(['id' => 1]);
+        $request->validate([
+            'email' => ['required', 'email'],
+        ]);
 
-        $token = Str::random(40);
-        $duration = (int) env('ADMIN_TOKEN_LIFETIME', 30);
-        $expires = Carbon::now()->addMinutes($duration)->timestamp;
-        $admin->reset_token = $token;
-        $admin->reset_token_expires = $expires;
-        $admin->save();
-
+        $inputEmail = $request->input('email');
         $email = env('ADMIN_BACKUP_EMAIL');
-        if ($email) {
+
+        if ($email && $inputEmail === $email) {
+            $admin = AdminPassword::firstOrCreate(['id' => 1]);
+
+            $token = Str::random(40);
+            $duration = (int) env('ADMIN_TOKEN_LIFETIME', 30);
+            $expires = Carbon::now()->addMinutes($duration)->timestamp;
+            $admin->reset_token = $token;
+            $admin->reset_token_expires = $expires;
+            $admin->save();
+
             $url = route('admin.setPassword', ['token' => $token]);
             Mail::to($email)->send(new AdminForgotPasswordMail($url));
+        } else {
+            return back()->withErrors(['email' => 'Adresse email incorrecte']);
         }
 
         return back();
@@ -134,6 +140,6 @@ class AdminController extends Controller
         $request->session()->put('admin_login_token', $token);
         $request->session()->put('admin_login_token_expires', $expires);
 
-        return redirect()->route('admin.login', ['token' => $token]);
+        return redirect()->route('admin.login');
     }
 }

--- a/resources/js/Pages/Admin/Login.tsx
+++ b/resources/js/Pages/Admin/Login.tsx
@@ -1,16 +1,24 @@
 import { router } from '@inertiajs/react';
 import { FormEvent, useState } from 'react';
 
-export default function AdminLogin({ token }: { token: string }) {
+export default function AdminLogin() {
     const [password, setPassword] = useState('');
 
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        router.post('/admin/login', { password, token });
+        router.post('/admin/login', { password });
     }
 
+    const [email, setEmail] = useState('');
+    const [showForgot, setShowForgot] = useState(false);
+
     function handleForgot() {
-        router.post('/admin/forgot-password');
+        setShowForgot(true);
+    }
+
+    function handleForgotSubmit(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        router.post('/admin/forgot-password', { email });
     }
 
     return (
@@ -29,13 +37,28 @@ export default function AdminLogin({ token }: { token: string }) {
                     Valider
                 </button>
             </form>
-            <button
-                type="button"
-                onClick={handleForgot}
-                className="text-sm underline"
-            >
-                Mot de passe oubli\u00E9 ?
-            </button>
+            {showForgot ? (
+                <form onSubmit={handleForgotSubmit} className="flex gap-2 text-sm">
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="rounded border p-2"
+                        placeholder="Email de r\u00E9cup\u00E9ration"
+                    />
+                    <button type="submit" className="rounded bg-blue-600 px-2 py-1 text-white">
+                        Confirmer
+                    </button>
+                </form>
+            ) : (
+                <button
+                    type="button"
+                    onClick={handleForgot}
+                    className="text-sm underline"
+                >
+                    Mot de passe oubli\u00E9 ?
+                </button>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- require admins to confirm recovery email before sending reset link
- store login token only in session and remove tokens from URLs
- update admin login page to include email confirmation for forgotten passwords

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685685abc4148328b97010deeba71ada