### PR TITLE
Redirect unauthorized and missing pages to home

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -18,7 +18,7 @@ class AdminController extends Controller
     {
         $sequence = $request->input('sequence', []);
         if ($sequence !== explode(',', (string) env('ADMIN_SEQUENCE'))) {
-            abort(403);
+            return redirect()->route('home');
         }
 
         $token = Str::random(40);
@@ -35,7 +35,7 @@ class AdminController extends Controller
         $token = $request->session()->get('admin_login_token');
         $expires = $request->session()->get('admin_login_token_expires');
         if (!$token || $expires < time()) {
-            abort(403);
+            return redirect()->route('home');
         }
 
         return Inertia::render('Admin/Login');
@@ -46,7 +46,7 @@ class AdminController extends Controller
         $token = $request->session()->get('admin_login_token');
         $expires = $request->session()->get('admin_login_token_expires');
         if (!$token || $expires < time()) {
-            abort(403);
+            return redirect()->route('home');
         }
 
         $request->validate([
@@ -109,7 +109,7 @@ class AdminController extends Controller
         $admin = AdminPassword::find(1);
         $token = $request->query('token');
         if (!$admin || !$admin->reset_token || $admin->reset_token !== $token || $admin->reset_token_expires < time()) {
-            abort(403);
+            return redirect()->route('home');
         }
 
         return Inertia::render('Admin/SetPassword', [
@@ -122,7 +122,7 @@ class AdminController extends Controller
         $admin = AdminPassword::find(1);
         $token = $request->input('token');
         if (!$admin || !$admin->reset_token || $admin->reset_token !== $token || $admin->reset_token_expires < time()) {
-            abort(403);
+            return redirect()->route('home');
         }
 
         $request->validate([

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -10,7 +10,7 @@ class Admin
     public function handle(Request $request, Closure $next)
     {
         if (!$request->session()->get('is_admin')) {
-            return response()->json(['error' => 'Forbidden'], 403);
+            return redirect()->route('home');
         }
 
         return $next($request);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -23,5 +23,9 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->renderable(function (\Symfony\Component\HttpKernel\Exception\HttpExceptionInterface $e) {
+            if (in_array($e->getStatusCode(), [403, 404])) {
+                return redirect()->route('home');
+            }
+        });
     })->create();

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,3 +37,7 @@ Route::post('/admin/logout', [AdminController::class, 'logout'])->name('admin.lo
 Route::post('/admin/forgot-password', [AdminController::class, 'forgotPassword'])->name('admin.forgot');
 Route::get('/admin/set-password', [AdminController::class, 'setPasswordPage'])->name('admin.setPassword');
 Route::post('/admin/set-password', [AdminController::class, 'setPassword'])->name('admin.setPassword.post');
+
+Route::fallback(function () {
+    return redirect()->route('home');
+});


### PR DESCRIPTION
## Summary
- redirect 403 and 404 responses globally via application exception handler
- return home when an admin route is accessed without being logged in
- send users to home page for unmatched routes
- update admin controller checks to redirect instead of aborting

## Testing
- `npx vitest run` *(fails: 403 Forbidden from npm registry)*
- `php vendor/bin/phpunit --no-coverage` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68568df3fd5c8328824586337eee1ea3