### PR TITLE
Add generic toast notifications

### DIFF
--- a/resources/js/Components/Toast.tsx
+++ b/resources/js/Components/Toast.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+
+export type ToastVariant = 'success' | 'error';
+
+export interface ToastProps {
+    id: number;
+    title?: string;
+    description?: string;
+    variant?: ToastVariant;
+    duration?: number;
+    onClose: (id: number) => void;
+}
+
+export default function Toast({
+    id,
+    title,
+    description,
+    variant = 'success',
+    duration = 7500,
+    onClose,
+}: ToastProps) {
+    const [progress, setProgress] = useState(100);
+
+    useEffect(() => {
+        const start = Date.now();
+        const interval = setInterval(() => {
+            const elapsed = Date.now() - start;
+            const percentage = 100 - (elapsed / duration) * 100;
+            if (percentage <= 0) {
+                clearInterval(interval);
+                onClose(id);
+            } else {
+                setProgress(percentage);
+            }
+        }, 50);
+        return () => clearInterval(interval);
+    }, [duration, id, onClose]);
+
+    const colorClasses =
+        variant === 'success'
+            ? 'bg-green-50 border-green-400 text-green-800'
+            : 'bg-red-50 border-red-400 text-red-800';
+    const barColor = variant === 'success' ? 'bg-green-500' : 'bg-red-500';
+
+    return (
+        <div
+            className={`relative w-64 overflow-hidden rounded border px-4 py-2 shadow ${colorClasses}`}
+        >
+            <button
+                type="button"
+                className="absolute left-2 top-2 text-xs font-bold"
+                onClick={() => onClose(id)}
+            >
+                ×
+            </button>
+            {title && <p className="font-bold">{title}</p>}
+            {description && (
+                <p className="text-sm leading-snug">{description}</p>
+            )}
+            <div
+                className={`absolute bottom-0 left-0 h-1 ${barColor}`}
+                style={{ width: `${progress}%` }}
+            />
+        </div>
+    );
+}

--- a/resources/js/Components/ToastProvider.tsx
+++ b/resources/js/Components/ToastProvider.tsx
@@ -1,0 +1,38 @@
+import { createContext, PropsWithChildren, useContext, useState } from 'react';
+import Toast, { ToastProps } from './Toast';
+
+interface ToastContextType {
+    addToast: (toast: Omit<ToastProps, 'id' | 'onClose'>) => void;
+}
+
+const ToastContext = createContext<ToastContextType>({
+    addToast: () => {},
+});
+
+export function useToast() {
+    return useContext(ToastContext);
+}
+
+export default function ToastProvider({ children }: PropsWithChildren) {
+    const [toasts, setToasts] = useState<ToastProps[]>([]);
+
+    const addToast = (toast: Omit<ToastProps, 'id' | 'onClose'>) => {
+        const id = Date.now() + Math.random();
+        setToasts((prev) => [...prev, { ...toast, id }]);
+    };
+
+    const removeToast = (id: number) => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+    };
+
+    return (
+        <ToastContext.Provider value={{ addToast }}>
+            {children}
+            <div className="fixed right-4 top-4 z-50 flex flex-col items-end space-y-2">
+                {toasts.map((toast) => (
+                    <Toast key={toast.id} {...toast} onClose={removeToast} />
+                ))}
+            </div>
+        </ToastContext.Provider>
+    );
+}

--- a/resources/js/Pages/Admin/Login.tsx
+++ b/resources/js/Pages/Admin/Login.tsx
@@ -1,10 +1,12 @@
 import { router } from '@inertiajs/react';
 import { FormEvent, useState } from 'react';
+import { useToast } from '@/Components/ToastProvider';
 
 export default function AdminLogin() {
     const [password, setPassword] = useState('');
     const [email, setEmail] = useState('');
     const [showForgot, setShowForgot] = useState(false);
+    const { addToast } = useToast();
 
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -17,7 +19,14 @@ export default function AdminLogin() {
 
     function handleForgotSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        router.post('/admin/forgot-password', { email });
+        router.post('/admin/forgot-password', { email }, {
+            onSuccess: () =>
+                addToast({
+                    title: 'Email envoyé',
+                    description: "Un mail de réinitialisation a été envoyé.",
+                    variant: 'success',
+                }),
+        });
     }
 
     return (

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -4,6 +4,7 @@ import './bootstrap';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
+import ToastProvider from './Components/ToastProvider';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -17,7 +18,11 @@ createInertiaApp({
     setup({ el, App, props }) {
         const root = createRoot(el);
 
-        root.render(<App {...props} />);
+        root.render(
+            <ToastProvider>
+                <App {...props} />
+            </ToastProvider>,
+        );
     },
     progress: {
         color: '#4B5563',


### PR DESCRIPTION
## Summary
- add generic toast component with provider
- wrap Inertia app with ToastProvider
- show toast after admin recovery email is sent successfully

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path' – eslint not configured in container)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856929d06fc8328906edf49fac47fdc