### PR TITLE
Adjust layout widths and image styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+img {
+    max-width: 100%;
+    height: auto;
+}

--- a/resources/js/Layouts/Footer.tsx
+++ b/resources/js/Layouts/Footer.tsx
@@ -4,7 +4,7 @@ import { Link } from '@inertiajs/react';
 export default function Footer() {
     return (
         <div>
-            <footer className="mt-24 rounded-t-xl bg-[#446D49] p-5 font-bold text-white md:flex md:justify-between">
+            <footer className="mt-24 w-full rounded-t-xl bg-[#446D49] p-5 font-bold text-white md:flex md:justify-between">
                 <div className="grid w-[33%] grid-cols-[1fr_2fr] items-center">
                     <Link href="/" className="flex justify-center">
                         <ApplicationLogo className="block h-auto w-[80%] fill-current text-gray-800 dark:text-gray-200" />

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -45,7 +45,7 @@ export default function FrontOffice({
             >
                 {header}
             </div>
-            <main className="mx-auto w-full max-w-[950px] flex-grow px-4 py-8">
+            <main className="mx-auto w-full max-w-[1100px] flex-grow px-5 py-8">
                 {children}
             </main>
             <Footer />

--- a/resources/js/Layouts/Header.tsx
+++ b/resources/js/Layouts/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
     }
     return (
         <div>
-            <header className="sticky top-0 z-20 flex justify-between rounded-b-xl bg-white p-5 uppercase">
+            <header className="sticky top-0 z-20 flex w-full justify-between rounded-b-xl bg-[#446D49] p-5 uppercase text-white">
                 <Link href="/">
                     <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200" />
                 </Link>


### PR DESCRIPTION
## Summary
- ensure header color matches footer
- make header and footer span full width
- give main layout max width 1100px with padding
- ensure images maintain aspect ratio

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint flag issue)*
- `npm run check-types` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0025ab083289168f1dfbda84fcd