### PR TITLE
Adjust image fit and responsive layout

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+}

--- a/resources/js/Layouts/Footer.tsx
+++ b/resources/js/Layouts/Footer.tsx
@@ -4,8 +4,8 @@ import { Link } from '@inertiajs/react';
 export default function Footer() {
     return (
         <div>
-            <footer className="mt-24 rounded-t-xl bg-[#446D49] p-5 font-bold text-white md:flex md:justify-between">
-                <div className="grid w-[33%] grid-cols-[1fr_2fr] items-center">
+            <footer className="mt-24 w-full rounded-t-xl bg-[#446D49] p-5 font-bold text-white md:flex md:justify-between">
+                <div className="grid w-full grid-cols-[1fr_2fr] items-center md:w-1/3 md:mb-0 mb-4">
                     <Link href="/" className="flex justify-center">
                         <ApplicationLogo className="block h-auto w-[80%] fill-current text-gray-800 dark:text-gray-200" />
                     </Link>

--- a/resources/js/Layouts/Footer.tsx
+++ b/resources/js/Layouts/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
     return (
         <div>
             <footer className="mt-24 w-full rounded-t-xl bg-[#446D49] p-5 font-bold text-white md:flex md:justify-between">
-                <div className="grid w-full grid-cols-[1fr_2fr] items-center md:w-1/3 md:mb-0 mb-4">
+                <div className="mb-4 grid grid-cols-[1fr_2fr] items-center md:mb-0">
                     <Link href="/" className="flex justify-center">
                         <ApplicationLogo className="block h-auto w-[80%] fill-current text-gray-800 dark:text-gray-200" />
                     </Link>

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -32,7 +32,7 @@ export default function FrontOffice({
     }, [props.adminSequence]);
     return (
         <div
-            className="absolute -z-10 bg-top bg-repeat-y"
+            className="min-h-screen bg-top bg-repeat-y"
             style={{
                 backgroundImage: `url(${backgroundVector})`,
                 backgroundSize: '100% auto',

--- a/resources/js/Layouts/FrontOfficeLayout.tsx
+++ b/resources/js/Layouts/FrontOfficeLayout.tsx
@@ -40,12 +40,12 @@ export default function FrontOffice({
         >
             <Header />
             <div
-                className="flex h-[340px] items-end bg-stone-900 bg-cover bg-center p-4"
+                className="flex h-[200px] md:h-[340px] items-end bg-stone-900 bg-cover bg-center p-4"
                 style={{ backgroundImage: `url(${image})` }}
             >
                 {header}
             </div>
-            <main className="mx-auto w-full max-w-[950px] flex-grow px-4 py-8">
+            <main className="mx-auto w-full max-w-[1100px] flex-grow px-5 py-8">
                 {children}
             </main>
             <Footer />

--- a/resources/js/Layouts/Header.tsx
+++ b/resources/js/Layouts/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
     }
     return (
         <div>
-            <header className="sticky top-0 z-20 flex justify-between rounded-b-xl bg-white p-5 uppercase">
+            <header className="sticky top-0 z-20 flex w-full justify-between rounded-b-xl bg-[#446D49] p-5 uppercase text-white">
                 <Link href="/">
                     <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200" />
                 </Link>

--- a/resources/js/Pages/Home.tsx
+++ b/resources/js/Pages/Home.tsx
@@ -106,7 +106,7 @@ export default function Home() {
                     alt="Emplacement de l'AMAP au sein de la ville d'Angers"
                     srcSet={`${map} 800w, ${largeMap} 1200w`}
                     sizes="(max-width: 800px) 100vw, 100vw"
-                    className="h-full w-full object-cover"
+                    className="h-full w-full object-contain"
                 />
 
                 {/* <img


### PR DESCRIPTION
## Summary
- make all images use `object-fit: contain`
- tune hero section height for small screens
- improve footer width at small breakpoints
- render map image with `object-contain`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint flag issue)*
- `npm run check-types` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0025ab083289168f1dfbda84fcd