### PR TITLE
Fix test mocks for Inertia

### DIFF
--- a/tests/contact.test.tsx
+++ b/tests/contact.test.tsx
@@ -1,15 +1,21 @@
 // tests/UserForm.test.jsx
-import { Inertia } from '@inertiajs/inertia';
+import { router } from '@inertiajs/react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import Contact from '../resources/js/Pages/Contact';
 
-vi.mock('@inertiajs/inertia'); // Mock Inertia for POST requests
+vi.mock('@inertiajs/react', () => {
+    return {
+        router: { post: vi.fn() },
+        usePage: () => ({ props: { adminSequence: [] } }),
+        Link: (props: any) => <a {...props}>{props.children}</a>,
+    };
+});
 
 describe('Contact form', () => {
-    it('submits form data via Inertia.post', async () => {
+    it('submits form data via router.post', async () => {
         const mockPost = vi.fn();
-        Inertia.post = mockPost;
+        (router as any).post = mockPost;
 
         render(<Contact />);
 

--- a/tests/producers.test.tsx
+++ b/tests/producers.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import Producers from '../resources/js/Pages/Producers';
 
 vi.mock('@inertiajs/react', () => ({
-    usePage: () => ({ props: { isAdmin: true } }),
+    usePage: () => ({ props: { isAdmin: true, adminSequence: [] } }),
+    router: { post: vi.fn() },
+    Link: (props: any) => <a {...props}>{props.children}</a>,
 }));
 
 global.fetch = vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- mock `@inertiajs/react` exports in tests
- adapt Contact test to use router.post

## Testing
- `pnpm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ce09455483289d9b407dd7c7b1f1