### PR TITLE
Add multiple photos to producers

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -12,10 +12,20 @@ class ImageController extends Controller
         $data = $request->validate([
             'title' => ['required', 'string'],
             'alt_text' => ['required', 'string'],
-            'url' => ['required', 'string'],
+            'file' => ['required', 'file', 'image'],
         ]);
 
-        Image::create($data);
+        $file = $data['file'];
+        unset($data['file']);
+
+        $binary = file_get_contents($file->getRealPath());
+
+        Image::create([
+            'title' => $data['title'],
+            'alt_text' => $data['alt_text'],
+            'url' => 'data:' . $file->getMimeType() . ';base64,' . base64_encode($binary),
+            'data' => $binary,
+        ]);
 
         return 'success';
     }
@@ -35,10 +45,20 @@ class ImageController extends Controller
         $data = $request->validate([
             'title' => ['required', 'string'],
             'alt_text' => ['required', 'string'],
-            'url' => ['required', 'string'],
+            'file' => ['file', 'image'],
         ]);
 
-        Image::findOrFail($id)->update($data);
+        $image = Image::findOrFail($id);
+        $image->title = $data['title'];
+        $image->alt_text = $data['alt_text'];
+
+        if ($request->file('file')) {
+            $binary = file_get_contents($request->file('file')->getRealPath());
+            $image->data = $binary;
+            $image->url = 'data:' . $request->file('file')->getMimeType() . ';base64,' . base64_encode($binary);
+        }
+
+        $image->save();
 
         return ['success' => 'image mis à jour'];
     }

--- a/app/Http/Controllers/ProducerController.php
+++ b/app/Http/Controllers/ProducerController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Producer;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 
 class ProducerController extends Controller
@@ -17,21 +18,30 @@ class ProducerController extends Controller
             'zipcode' => ['required', 'string'],
             'city' => ['required', 'string'],
             'description' => ['required', 'string'],
+            'pictures' => ['array'],
+            'pictures.*' => ['integer'],
         ]);
 
-        Producer::create($data);
+        $pictures = $data['pictures'] ?? [];
+        unset($data['pictures']);
+
+        $producer = Producer::create($data);
+
+        if (!empty($pictures)) {
+            $producer->images()->attach($pictures);
+        }
 
         return 'success';
     }
 
     public function allProducers()
     {
-        return Producer::all();
+        return Producer::with('images')->get();
     }
 
     public function getProducer(int $id)
     {
-        return Producer::find($id);
+        return Producer::with('images')->find($id);
     }
 
     public function editProducer(int $id, Request $request)
@@ -44,9 +54,16 @@ class ProducerController extends Controller
             'zipcode' => ['required', 'string'],
             'city' => ['required', 'string'],
             'description' => ['required', 'string'],
+            'pictures' => ['array'],
+            'pictures.*' => ['integer'],
         ]);
 
-        Producer::findOrFail($id)->update($data);
+        $pictures = $data['pictures'] ?? [];
+        unset($data['pictures']);
+
+        $producer = Producer::findOrFail($id);
+        $producer->update($data);
+        $producer->images()->sync($pictures);
 
         return ['success' => 'Producer mis à jour'];
     }

--- a/app/Http/Controllers/ProducerController.php
+++ b/app/Http/Controllers/ProducerController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Producer;
-use Illuminate\Support\Arr;
+use App\Models\Image;
 use Illuminate\Http\Request;
 
 class ProducerController extends Controller
@@ -19,16 +19,28 @@ class ProducerController extends Controller
             'city' => ['required', 'string'],
             'description' => ['required', 'string'],
             'pictures' => ['array'],
-            'pictures.*' => ['integer'],
+            'pictures.*' => ['file', 'image'],
         ]);
 
-        $pictures = $data['pictures'] ?? [];
+        $files = $request->file('pictures', []);
         unset($data['pictures']);
 
         $producer = Producer::create($data);
 
-        if (!empty($pictures)) {
-            $producer->images()->attach($pictures);
+        $ids = [];
+        foreach ($files as $file) {
+            $binary = file_get_contents($file->getRealPath());
+            $image = Image::create([
+                'title' => $file->getClientOriginalName(),
+                'alt_text' => $file->getClientOriginalName(),
+                'url' => 'data:' . $file->getMimeType() . ';base64,' . base64_encode($binary),
+                'data' => $binary,
+            ]);
+            $ids[] = $image->id;
+        }
+
+        if (!empty($ids)) {
+            $producer->images()->attach($ids);
         }
 
         return 'success';
@@ -55,15 +67,30 @@ class ProducerController extends Controller
             'city' => ['required', 'string'],
             'description' => ['required', 'string'],
             'pictures' => ['array'],
-            'pictures.*' => ['integer'],
+            'pictures.*' => ['file', 'image'],
         ]);
 
-        $pictures = $data['pictures'] ?? [];
+        $files = $request->file('pictures', []);
         unset($data['pictures']);
 
         $producer = Producer::findOrFail($id);
         $producer->update($data);
-        $producer->images()->sync($pictures);
+
+        $ids = [];
+        foreach ($files as $file) {
+            $binary = file_get_contents($file->getRealPath());
+            $image = Image::create([
+                'title' => $file->getClientOriginalName(),
+                'alt_text' => $file->getClientOriginalName(),
+                'url' => 'data:' . $file->getMimeType() . ';base64,' . base64_encode($binary),
+                'data' => $binary,
+            ]);
+            $ids[] = $image->id;
+        }
+
+        if (!empty($ids)) {
+            $producer->images()->syncWithoutDetaching($ids);
+        }
 
         return ['success' => 'Producer mis à jour'];
     }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -15,6 +15,7 @@ class Image extends Model
         'title',
         'alt_text',
         'url',
+        'data',
     ];
 
     public function producers()

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -16,4 +16,9 @@ class Image extends Model
         'alt_text',
         'url',
     ];
+
+    public function producers()
+    {
+        return $this->belongsToMany(Producer::class, 'producer_images', 'image_id', 'producer_id');
+    }
 }

--- a/app/Models/Producer.php
+++ b/app/Models/Producer.php
@@ -20,4 +20,9 @@ class Producer extends Model
         'city',
         'description',
     ];
+
+    public function images()
+    {
+        return $this->belongsToMany(Image::class, 'producer_images', 'producer_id', 'image_id');
+    }
 }

--- a/database/migrations/2025_05_07_130100_create_producer_images_table.php
+++ b/database/migrations/2025_05_07_130100_create_producer_images_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('producer_images', function (Blueprint $table) {
+            $table->foreignId('producer_id');
+            $table->foreignId('image_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('producer_images');
+    }
+};

--- a/database/migrations/2025_05_07_130200_add_data_to_images_table.php
+++ b/database/migrations/2025_05_07_130200_add_data_to_images_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('images', function (Blueprint $table) {
+            $table->binary('data')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('images', function (Blueprint $table) {
+            $table->dropColumn('data');
+        });
+    }
+};

--- a/resources/js/Pages/Producers.tsx
+++ b/resources/js/Pages/Producers.tsx
@@ -81,44 +81,17 @@ export default function Producers() {
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
         const form = e.currentTarget;
-        const data = {
-            first_name: (
-                form.elements.namedItem('first_name') as HTMLInputElement
-            ).value,
-            last_name: (
-                form.elements.namedItem('last_name') as HTMLInputElement
-            ).value,
-            address_road: (
-                form.elements.namedItem('address_road') as HTMLInputElement
-            ).value,
-            zipcode: (form.elements.namedItem('zipcode') as HTMLInputElement)
-                .value,
-            city: (form.elements.namedItem('city') as HTMLInputElement).value,
-            description: (
-                form.elements.namedItem('description') as HTMLInputElement
-            ).value,
-            profile_picture: '1',
-            pictures: (
-                form.elements.namedItem('pictures') as HTMLInputElement
-            ).value
-                .split(',')
-                .map((v) => parseInt(v, 10))
-                .filter((v) => !Number.isNaN(v)),
-        };
+        const data = new FormData(form);
+        data.append('profile_picture', '1');
+
         const request = editing
             ? fetch(route('producers.update', editing.id), {
                   method: 'PUT',
-                  headers: {
-                      'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify(data),
+                  body: data,
               })
             : fetch(route('producers.store'), {
                   method: 'POST',
-                  headers: {
-                      'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify(data),
+                  body: data,
               });
         request.then(() => {
             setShowModal(false);
@@ -294,15 +267,12 @@ export default function Producers() {
                         required
                         className="w-full rounded"
                     />
-                    <InputLabel htmlFor="pictures">
-                        Photos (IDs séparés par des virgules)
-                    </InputLabel>
+                    <InputLabel htmlFor="pictures">Photos</InputLabel>
                     <TextInput
                         id="pictures"
-                        name="pictures"
-                        defaultValue={
-                            editing?.images.map((i) => i.id).join(',') ?? ''
-                        }
+                        name="pictures[]"
+                        type="file"
+                        multiple
                         className="w-full rounded"
                     />
                     <div className="flex justify-end gap-2 pt-4">

--- a/resources/js/Pages/Producers.tsx
+++ b/resources/js/Pages/Producers.tsx
@@ -11,6 +11,13 @@ import nearFarmers from '@images/near_farmers.jpg';
 import { usePage } from '@inertiajs/react';
 import { FormEvent, useEffect, useState } from 'react';
 
+interface Image {
+    id: number;
+    title: string;
+    alt_text: string;
+    url: string;
+}
+
 interface Producer {
     id: number;
     profile_picture: number;
@@ -20,6 +27,7 @@ interface Producer {
     zipcode: number;
     city: string;
     description: string;
+    images: Image[];
 }
 
 export default function Producers() {
@@ -90,6 +98,12 @@ export default function Producers() {
                 form.elements.namedItem('description') as HTMLInputElement
             ).value,
             profile_picture: '1',
+            pictures: (
+                form.elements.namedItem('pictures') as HTMLInputElement
+            ).value
+                .split(',')
+                .map((v) => parseInt(v, 10))
+                .filter((v) => !Number.isNaN(v)),
         };
         const request = editing
             ? fetch(route('producers.update', editing.id), {
@@ -158,6 +172,7 @@ export default function Producers() {
                             <>
                                 <img
                                     src={
+                                        p.images[0]?.url ||
                                         placeholders[
                                             index % placeholders.length
                                         ]
@@ -217,6 +232,7 @@ export default function Producers() {
                                 </div>
                                 <img
                                     src={
+                                        p.images[0]?.url ||
                                         placeholders[
                                             index % placeholders.length
                                         ]
@@ -276,6 +292,17 @@ export default function Producers() {
                         name="description"
                         defaultValue={editing?.description ?? ''}
                         required
+                        className="w-full rounded"
+                    />
+                    <InputLabel htmlFor="pictures">
+                        Photos (IDs séparés par des virgules)
+                    </InputLabel>
+                    <TextInput
+                        id="pictures"
+                        name="pictures"
+                        defaultValue={
+                            editing?.images.map((i) => i.id).join(',') ?? ''
+                        }
                         className="w-full rounded"
                     />
                     <div className="flex justify-end gap-2 pt-4">

--- a/tests/producers.test.tsx
+++ b/tests/producers.test.tsx
@@ -14,6 +14,7 @@ global.fetch = vi.fn().mockResolvedValue({
             {
                 id: 1,
                 profile_picture: 1,
+                images: [],
                 first_name: 'John',
                 last_name: 'Doe',
                 address_road: '1 rue test',


### PR DESCRIPTION
## Summary
- allow producers to have many images via `producer_images` pivot table
- expose images relation in Producer model and controller
- update frontend producer form to accept photo IDs
- display first photo for each producer
- adjust tests for new API

## Testing
- `pnpm lint`
- `pnpm check-types`
- `pnpm unit-test-once`


------
https://chatgpt.com/codex/tasks/task_e_6856ed6435408328b9191c62766f1c5a