### PR TITLE
Improve password reset UX

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -50,7 +50,7 @@ class AdminController extends Controller
         }
 
         $request->validate([
-            'password' => ['required'],
+            'password' => ['required', 'confirmed'],
         ]);
 
         $admin = AdminPassword::find(1);
@@ -126,7 +126,7 @@ class AdminController extends Controller
         }
 
         $request->validate([
-            'password' => ['required'],
+            'password' => ['required', 'confirmed'],
         ]);
 
         $admin->password = Hash::make($request->input('password'));
@@ -140,6 +140,11 @@ class AdminController extends Controller
         $request->session()->put('admin_login_token', $token);
         $request->session()->put('admin_login_token_expires', $expires);
 
-        return redirect()->route('admin.login');
+        return redirect()->route('admin.passwordChanged');
+    }
+
+    public function passwordChangedPage(): Response
+    {
+        return Inertia::render('Admin/PasswordChanged');
     }
 }

--- a/resources/js/Components/NavLink.tsx
+++ b/resources/js/Components/NavLink.tsx
@@ -13,7 +13,7 @@ export default function NavLink({
                 'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium leading-5 transition duration-150 ease-in-out focus:outline-none ' +
                 (active
                     ? 'border-indigo-400 text-gray-900 focus:border-indigo-700 dark:border-indigo-600 dark:text-gray-100'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 focus:border-gray-300 focus:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-300 dark:focus:border-gray-700 dark:focus:text-gray-300') +
+                    : 'border-transparent text-gray-200 hover:border-gray-300 hover:text-white focus:border-gray-300 focus:text-white dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-300 dark:focus:border-gray-700 dark:focus:text-gray-300') +
                 className
             }
         >

--- a/resources/js/Components/TextInput.tsx
+++ b/resources/js/Components/TextInput.tsx
@@ -32,7 +32,7 @@ export default forwardRef(function TextInput(
             {...props}
             type={type}
             className={
-                'rounded-md border-gray-300 text-black shadow-sm focus:border-indigo-500 focus:ring-indigo-500' +
+                'rounded-md border-gray-300 text-black shadow-sm focus:border-indigo-500 focus:ring-indigo-500 pr-6 ' +
                 className
             }
             ref={localRef}

--- a/resources/js/Pages/Admin/Login.tsx
+++ b/resources/js/Pages/Admin/Login.tsx
@@ -46,7 +46,7 @@ export default function AdminLogin() {
                             type="password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                            className="rounded border p-2"
+                            className="rounded border p-2 pr-6"
                             placeholder="Mot de passe"
                         />
                         <button
@@ -74,7 +74,7 @@ export default function AdminLogin() {
                             type="email"
                             value={email}
                             onChange={(e) => setEmail(e.target.value)}
-                            className="rounded border p-2"
+                            className="rounded border p-2 pr-6"
                             placeholder="Email de récupération"
                         />
                         <button

--- a/resources/js/Pages/Admin/PasswordChanged.tsx
+++ b/resources/js/Pages/Admin/PasswordChanged.tsx
@@ -1,0 +1,12 @@
+import FrontOfficeLayout from '@/Layouts/FrontOfficeLayout';
+
+export default function PasswordChanged() {
+    return (
+        <FrontOfficeLayout>
+            <div className="flex h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+                <h1 className="text-2xl font-bold">Mot de passe mis à jour</h1>
+                <p>Vous pouvez maintenant fermer cet onglet et retourner vous connecter sur l'espace administrateur.</p>
+            </div>
+        </FrontOfficeLayout>
+    );
+}

--- a/resources/js/Pages/Admin/SetPassword.tsx
+++ b/resources/js/Pages/Admin/SetPassword.tsx
@@ -1,23 +1,66 @@
+import { useToast } from '@/Components/ToastProvider';
 import { router } from '@inertiajs/react';
 import { FormEvent, useState } from 'react';
 
 export default function SetPassword({ token }: { token: string }) {
     const [password, setPassword] = useState('');
+    const [confirm, setConfirm] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirm, setShowConfirm] = useState(false);
+    const { addToast } = useToast();
 
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        router.post('/admin/set-password', { password, token });
+        router.post(
+            '/admin/set-password',
+            { password, password_confirmation: confirm, token },
+            {
+                onSuccess: () => {
+                    addToast({
+                        title: 'Mot de passe changé',
+                        variant: 'success',
+                    });
+                    router.visit('/admin/password-changed');
+                },
+            },
+        );
     }
 
     return (
         <div className="flex h-screen flex-col items-center justify-center gap-4">
-            <form onSubmit={handleSubmit} className="flex items-center gap-2">
-                <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="rounded border p-2"
-                />
+            <form onSubmit={handleSubmit} className="flex flex-col items-center gap-2">
+                <div className="relative">
+                    <input
+                        type={showPassword ? 'text' : 'password'}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="rounded border p-2 pr-6"
+                        placeholder="Nouveau mot de passe"
+                    />
+                    <button
+                        type="button"
+                        className="absolute right-1 top-1/2 -translate-y-1/2"
+                        onClick={() => setShowPassword(!showPassword)}
+                    >
+                        {showPassword ? '🙈' : '👁'}
+                    </button>
+                </div>
+                <div className="relative">
+                    <input
+                        type={showConfirm ? 'text' : 'password'}
+                        value={confirm}
+                        onChange={(e) => setConfirm(e.target.value)}
+                        className="rounded border p-2 pr-6"
+                        placeholder="Confirmer le mot de passe"
+                    />
+                    <button
+                        type="button"
+                        className="absolute right-1 top-1/2 -translate-y-1/2"
+                        onClick={() => setShowConfirm(!showConfirm)}
+                    >
+                        {showConfirm ? '🙈' : '👁'}
+                    </button>
+                </div>
                 <button
                     type="submit"
                     className="rounded bg-blue-600 px-4 py-2 text-white"

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,7 @@ Route::post('/admin/logout', [AdminController::class, 'logout'])->name('admin.lo
 Route::post('/admin/forgot-password', [AdminController::class, 'forgotPassword'])->name('admin.forgot');
 Route::get('/admin/set-password', [AdminController::class, 'setPasswordPage'])->name('admin.setPassword');
 Route::post('/admin/set-password', [AdminController::class, 'setPassword'])->name('admin.setPassword.post');
+Route::get('/admin/password-changed', [AdminController::class, 'passwordChangedPage'])->name('admin.passwordChanged');
 
 Route::fallback(function () {
     return redirect()->route('home');


### PR DESCRIPTION
## Summary
- add a confirmation page after changing password
- enhance set password page with confirmation field, show/hide toggles and toast
- lighten inactive nav links
- add right padding to text inputs
- update routes and controller for password changed page

## Testing
- `pnpm lint-fix` *(fails: invalid option)*
- `pnpm check-types` *(fails: type errors)*
- `pnpm unit-test-once` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857df4b9ec48328a2818c88b5434192